### PR TITLE
Fix link type dropdown appearing underneat adjacent Bard set content

### DIFF
--- a/resources/js/components/fieldtypes/Hyperlink.vue
+++ b/resources/js/components/fieldtypes/Hyperlink.vue
@@ -3,7 +3,14 @@
 		<div class="hyperlink-config">
 			<div class="hyperlink-type">
 				<!-- Link type selector -->
-				<v-select v-model="type" :options="options" :disabled="isReadOnly" :clearable="false" :reduce="option => option.value"/>
+				<v-select
+					v-model="type"
+					append-to-body
+					:options="options"
+					:disabled="isReadOnly"
+					:clearable="false"
+					:reduce="option => option.value"
+				/>
 			</div>
 
 			<div class="hyperlink-input-url">


### PR DESCRIPTION
Statamic 4 introduced container queries into some field types and Bard set content. Container queries always create a new stacking context, which introduced a new issue (#9) where the Link Type dropdown would appear underneath adjacent Bard sets.

Adding the `append-to-body` directive to the dropdown resolves the issue by pushing the dropdown contents out of its parent stacking context and onto the document body.

