### PR TITLE
Fix missing link reference elements throwing PHP error

### DIFF
--- a/src/Helpers/HyperlinkData.php
+++ b/src/Helpers/HyperlinkData.php
@@ -115,17 +115,17 @@ class HyperlinkData implements Arrayable, Htmlable
 
         if ($this->type === 'entry') {
             $this->entry = \Statamic\Facades\Entry::find($this->getValue());
-            $this->url = $this->entry->url();
+            $this->url = $this->entry?->url();
         }
 
         if ($this->type === 'term') {
             $this->term = \Statamic\Facades\Term::find($this->getValue());
-            $this->url = $this->term->url();
+            $this->url = $this->term?->url();
         }
 
         if ($this->type === 'asset') {
             $this->asset = \Statamic\Facades\Asset::findById($this->getValue());
-            $this->url = $this->asset->url();
+            $this->url = $this->asset?->url();
         }
     }
 }

--- a/tests/Feature/DataTest.php
+++ b/tests/Feature/DataTest.php
@@ -62,3 +62,13 @@ it('resolves linked term relationships', function () {
         ->url->not()->toBeEmpty()
         ->url->not()->toStartWith('term::');
 });
+
+it('fails gracefully on broken linked relationships', function ($link, $property) {
+    expect($link->toData())
+        ->toHaveProperty($property, null)
+        ->url->toBeNull();
+})->with([
+    'entry' => [TestLink::entry('entry::BROKEN'), 'entry'],
+    'asset' => [TestLink::entry('asset::BROKEN'), 'asset'],
+    'term' => [TestLink::entry('term::BROKEN'), 'term'],
+]);


### PR DESCRIPTION
Fail gracefully when a link's related element can no longer be found (#13). Links will keep their target and text options, but will not output a URL. Visiting the entry in the control panel will highlight the undefined item using the normal behavior for Statamic's entries, assets, and terms components.